### PR TITLE
Addition of @loading event

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ Enable Auto Resizing on window resize. By default, autoresizing is disabled.
 #### @numpages <sup>Number<sup>
 The total number of pages of the pdf.
 
+#### @loading <sup>Boolean<sup>
+The provided PDF's loading state
+
 ### Public static methods
 
 #### createLoadingTask(src)

--- a/src/Pdfvuer.vue
+++ b/src/Pdfvuer.vue
@@ -140,6 +140,7 @@ export default {
 				this.pdfViewer.update(newScale,this.rotate);
 				this.pdfViewer.draw();
 				this.loading = false;
+				this.$emit('loading', false);
 			}
 		},
 		resizeScale: function(size) {
@@ -153,6 +154,7 @@ export default {
 		var self = this;
 		if(!isPDFDocumentLoadingTask(self.internalSrc)){
 				self.internalSrc = createLoadingTask(self.internalSrc);
+        self.$emit('loading', true);
 		}
 
 		var SEARCH_FOR = 'Mozilla'; // try 'Mozilla';


### PR DESCRIPTION
I've added two lines of code, each to emit a "loading" event. The event will be fired when the PDF is loaded and after the PDF has been drawn. I've added ```self.$emit('loading', true); ``` just after you invoke the ``` createLoadingTask ``` method. Hope that's correct!  🎉