### PR TITLE
fix: Set correct compression type when loading cmaps

### DIFF
--- a/src/Pdfvuer.vue
+++ b/src/Pdfvuer.vue
@@ -45,7 +45,7 @@ function createLoadingTask(src, options) {
 
 				return {
 					cMapData: bcmap,
-					compressionType: CMapCompressionType.BINARY,
+					compressionType: pdfjsLib.CMapCompressionType.BINARY,
 				};
 			});
 		}


### PR DESCRIPTION
Fixes issue #
Displaying pdf file that requires cmaps
### Describe the changes you have made in this PR -
Correctly referenced CMapCompressionType so it won't be undefined
### Have you updated the readme?
Nothing to update
### Screenshots of the changes (If any) -
Pdf that is not displayed properly
[article.pdf](https://github.com/arkokoley/pdfvuer/files/3370072/article.pdf)
