### PR TITLE
set pdfViewer to null when component gets distoryed

### DIFF
--- a/src/Pdfvuer.vue
+++ b/src/Pdfvuer.vue
@@ -226,6 +226,7 @@ export default {
     var self = this;
     if (self.pdfViewer) {
       self.pdfViewer.destroy();
+	  self.pdfViewer = null;
     }
   }
 }


### PR DESCRIPTION
Fixes issue #
When the component is destroyed it will call `resizeScale` method for the last time and calling the `drawScaled` method thus causing error below
![image](https://user-images.githubusercontent.com/25952288/65479102-bb5b8300-debe-11e9-8102-d941effe70cf.png)

### Describe the changes you have made in this PR -
Since `drawScaled` method has a checking if `pdfViewer` data exists before doing anything, so setting  `pdfViewer` data to null on before the component is destroyed should fix the issue.

### Have you updated the readme?
No
