### PR TITLE
fix: Fixes broken webpack build

### DIFF
--- a/src/Pdfvuer.vue
+++ b/src/Pdfvuer.vue
@@ -10,7 +10,6 @@
 <script>
   'use strict';
 
-  import 'pdfjs-dist/web/pdf_viewer.css';
   import pdfjsLib from 'pdfjs-dist/webpack.js';
   import { DefaultAnnotationLayerFactory, DefaultTextLayerFactory, PDFLinkService, PDFPageView } from 'pdfjs-dist/web/pdf_viewer.js';
   import resizeSensor from 'vue-resize-sensor'


### PR DESCRIPTION
This PR removes the manual import of PDFjs viewer CSS. The addition of this manual import breaks webpack. Removing the line does not affect the build (since CSS for dependencies should be autoloaded anyway). 

No changes to readme needed.
