### PR TITLE
Fix Pdfjs version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8926,7 +8926,7 @@
         },
         "os-locale": {
           "version": "1.4.0",
-          "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
@@ -9017,7 +9017,7 @@
         },
         "yargs": {
           "version": "6.6.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "core-js": "3",
-    "pdfjs-dist": "^2.3.200",
+    "pdfjs-dist": "2.3.200",
     "raw-loader": "^0.5.1",
     "vue-resize-sensor": "^2.0.0"
   },


### PR DESCRIPTION
### Issue
After installing `Pdfvuer` in a `Vue app` the app breaks and this error shows up
```
ERROR  Failed to compile with 1 errors
Failed to resolve loader: worker-loader
You may need to install it.
```

### Fix
After checking the dependencies turned out `Pdfjs` is the one that depends on `worker-loader`, so I changed its version specifically to the latest working one
https://github.com/mozilla/pdfjs-dist/commit/a3a0d672c2f3464e4bff95ad0a3b41341eb65a26#diff-b9cfc7f2cdf78a7f4b91a753d10865a2