### PR TITLE
fix: Explicitly import pdf worker entry to register global worker object

### DIFF
--- a/src/Pdfvuer.vue
+++ b/src/Pdfvuer.vue
@@ -17,6 +17,7 @@
       // pdfjsLib.GlobalWorkerOptions.workerPort = new PdfjsWorker();
     }
   }
+  import 'pdfjs-dist/build/pdf.worker.entry'
   import {
     DefaultAnnotationLayerFactory,
     DefaultTextLayerFactory,


### PR DESCRIPTION
Latest pdfvuer version does not contain pdf worker. Thus demo page served by `npm run serve` does not work due to following errors:

```
app.worker.js:1 Uncaught SyntaxError: Unexpected token '<'
```
```
Uncaught (in promise) Error: Setting up fake worker failed: "Cannot read property 'WorkerMessageHandler' of undefined".
```

### Describe the changes you have made in this PR -

This PR simply adds worker entry import to make worker globally accessible via `window` object.
Solved issue is probably related to #80.

### Have you updated the readme?

No

### Screenshots of the changes (If any) -

N/A
