### PR TITLE
fix: Pass required EventBus instance to PDFPageView

### DIFF
--- a/src/Pdfvuer.vue
+++ b/src/Pdfvuer.vue
@@ -21,7 +21,8 @@
     DefaultAnnotationLayerFactory,
     DefaultTextLayerFactory,
     PDFLinkService,
-    PDFPageView
+    PDFPageView,
+    EventBus
   } from 'pdfjs-dist/web/pdf_viewer.js';
   import resizeSensor from 'vue-resize-sensor'
 
@@ -173,6 +174,7 @@
             }),
             textLayerFactory: textLayer,
             annotationLayerFactory: annotationLayer,
+            eventBus: new EventBus()
           });
           self.loading = false;
           self.$emit('loading', false);


### PR DESCRIPTION
Latest version of pdfvuer produces a lot of console errors like this:

```
[Vue warn]: Error in callback for watcher "scale": "TypeError: Cannot read property 'dispatch' of undefined"

found in

---> <Pdf> at src/Pdfvuer.vue
       <Serve> at dev/serve.vue
         <Root>
```

This is caused by missing `EventBus` instance expected by `PDFPageView`.

### Describe the changes you have made in this PR -

Create `EventBus` instance and pass it to created `PDFPageView`

### Have you updated the readme?

No

### Screenshots of the changes (If any) -

N/A